### PR TITLE
Make types implement GMLPropertyType

### DIFF
--- a/geodesyml/0.3/src/main/resources/geodesyml-v_0_3.xjb
+++ b/geodesyml/0.3/src/main/resources/geodesyml-v_0_3.xjb
@@ -26,5 +26,11 @@
             <inheritance:implements>au.gov.ga.geodesy.support.gml.GMLPropertyType</inheritance:implements>
         </jaxb:bindings>
     </jaxb:bindings>
+
+    <jaxb:bindings schemaLocation="http://xml.gov.au/icsm/geodesyml/0.3/localInterferences.xsd" node="/xs:schema">
+        <jaxb:bindings multiple="true" node="//xs:complexType[substring(@name, string-length(@name) - string-length('PropertyType') + 1) = 'PropertyType']">
+            <inheritance:implements>au.gov.ga.geodesy.support.gml.GMLPropertyType</inheritance:implements>
+        </jaxb:bindings>
+    </jaxb:bindings>
 </jaxb:bindings>
 


### PR DESCRIPTION
So that we can properly map parent and nested elements using a GMLPropertyTypeMapper
Adding types declared in the localInterferences.xsd schema file