### PR TITLE
In CI, run `mvn package`, not `mvn test`

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-    nix-shell --command "mvn --settings travis/maven-settings.xml test"
+    nix-shell --command "mvn --settings travis/maven-settings.xml package"
 else
     cp scripts/travis/npmrc scripts/.npmrc
     nix-shell --command "mvn --settings travis/maven-settings.xml deploy"


### PR DESCRIPTION
Running `mvn package` packages geodesyml-v_0_4-scripts.zip, which is
required to complete the build.