### PR TITLE
Add LogItemPropertyType

### DIFF
--- a/geodesyml/0.4/src/main/java/au/gov/ga/geodesy/support/gml/LogItemPropertyType.java
+++ b/geodesyml/0.4/src/main/java/au/gov/ga/geodesy/support/gml/LogItemPropertyType.java
@@ -1,0 +1,36 @@
+package au.gov.ga.geodesy.support.gml;
+
+import net.opengis.gml.v_3_2_1.TimePositionType;
+
+/**
+ * GMLPropertyType with change tracking attributes.
+ *
+ * <pre>
+ * {@code
+ * <siteLog>
+ *     ...
+ *     <gnssReceiverProperty>
+ *         <GnssReceiver>
+ *             ...
+ *         </GnssReceier>
+ *         <dateInserted>...</dataInserted>
+ *         <dateDeleted>...</dataDeleted>
+ *         <deletedReason>...</deletedReason>
+ *     </gnssReceiverProperty>
+ *     ...
+ * </siteLog>
+ * }
+ * </pre>
+
+ * @see resource geodesyml-v_0_4.xjb
+ */
+public interface LogItemPropertyType extends GMLPropertyType {
+
+    TimePositionType getDateInserted();
+    TimePositionType getDateDeleted();
+    String getDeletedReason();
+
+    void setDateInserted(TimePositionType date);
+    void setDateDeleted(TimePositionType date);
+    void setDeletedReason(String reason);
+}

--- a/geodesyml/0.4/src/main/resources/geodesyml-v_0_4.xjb
+++ b/geodesyml/0.4/src/main/resources/geodesyml-v_0_4.xjb
@@ -76,7 +76,7 @@
             </jaxb:property>
         </jaxb:bindings>
         <jaxb:bindings multiple="true" node="//xs:complexType[substring(@name, string-length(@name) - string-length('PropertyType') + 1) = 'PropertyType']">
-            <inheritance:implements>au.gov.ga.geodesy.support.gml.GMLPropertyType</inheritance:implements>
+            <inheritance:implements>au.gov.ga.geodesy.support.gml.LogItemPropertyType</inheritance:implements>
         </jaxb:bindings>
     </jaxb:bindings>
 
@@ -88,7 +88,7 @@
 
     <jaxb:bindings schemaLocation="http://xml.gov.au/icsm/geodesyml/0.4/localInterferences.xsd" node="/xs:schema">
         <jaxb:bindings multiple="true" node="//xs:complexType[substring(@name, string-length(@name) - string-length('PropertyType') + 1) = 'PropertyType']">
-            <inheritance:implements>au.gov.ga.geodesy.support.gml.GMLPropertyType</inheritance:implements>
+            <inheritance:implements>au.gov.ga.geodesy.support.gml.LogItemPropertyType</inheritance:implements>
         </jaxb:bindings>
     </jaxb:bindings>
 </jaxb:bindings>


### PR DESCRIPTION
`LogItemPropertyType` abstracts over types with change tracking
properties, like `GnssReceiverPropertyType` and
`LocalEpisodicEffectPropertyType`.